### PR TITLE
Fix: 検索を日本語を含めず、英語の名前から取得した名前で曲を検索する

### DIFF
--- a/app/services/saved_playlists/based_on_saved_playlist_tracks_getter.rb
+++ b/app/services/saved_playlists/based_on_saved_playlist_tracks_getter.rb
@@ -1,72 +1,87 @@
 class SavedPlaylists::BasedOnSavedPlaylistTracksGetter < SpotifyService
   # saved_playlistの情報からクエリを作成、曲を取得、絞り込み
-  def self.call(saved_playlist)
-    new(saved_playlist).get
+  def self.call(saved_playlist, user)
+    new(saved_playlist, user).get
   end
 
-  def initialize(saved_playlist)
+  def initialize(saved_playlist, user)
     @saved_playlist = saved_playlist
+    @user = user
   end
   
   def get
-    fillter = saved_playlist.convert_fillter
-    querys, target_querys = saved_playlist.convert_querys(fillter)
-    ramdom_tracks = search_tracks(querys).flatten
-    target_tracks = search_tracks(target_querys) if target_querys.present?
+    year = saved_playlist.convert_year
+    if saved_playlist.only_follow_artist
+      artist_ids = saved_playlist.get_artist_ids
+      ramdom_tracks = search_tracks(artist_ids, year).flatten
+    end
+
+    if saved_playlist.include_artists
+      target_ids = saved_playlist.include_artists.ids 
+      target_tracks = search_tracks(target_ids, year)
+    end
+    
     return false if ramdom_tracks.nil? && target_tracks.nil?
 
-    refined_ramdom_and_target_tracks = refine_tracks(ramdom_tracks, target_tracks)
+    refined_ramdom_and_target_tracks = saved_playlist.refine_tracks(ramdom_tracks, target_tracks)
     return refined_ramdom_and_target_tracks
   end
 
   private
 
-  attr_reader :saved_playlist
+  attr_reader :saved_playlist, :user
 
-  def search_tracks(querys)
-    response = request_search_tracks(querys)
-    return response if response.nil?
-
-    tracks = response_convert_tracks(response)
+  def search_tracks(ids, year)
+    request_params = create_request_params(ids, year)
+    tracks = request_search_tracks(request_params)
     return tracks
   end
 
-  def request_search_tracks(querys)
-    tracks = []
-    querys.each do |query|
-      response = RSpotify::Base.search(query[:query], 'track', limit: 50)
-      artist_tracks = []
-      response.each do |res|
-        # アルバムのタイプがコンピレーション、または違うアーティストの曲は弾く
-        next if res.album.album_type == 'compilation' || res.artists.map { |artist| artist.id != query[:artist_spotify_id] }.all?
-        artist_tracks << res
-      end
-      tracks << artist_tracks.compact
+  def create_request_params(ids, year)
+    offset = INITIAL_VALUE
+    response = Array.new 
+    while true
+      response.concat(RSpotify::Artist.find(ids[offset, 50]))
+      break if ids.size == response.size
+      offset += PLUS_FIFTY
     end
-    tracks = nil unless tracks.flatten.any?
+    request_params = response.map do |res|
+                      string = "artist:#{res.name}"
+                      string += year if year
+                      {id: res.id, params: URI.encode_www_form_component(string)}
+                     end
+    
+    return request_params
+  end
+
+  def request_search_tracks(request_params)
+    tracks = request_params.map do |req|
+               response = conn_request.get("search?q=#{req[:params]}&type=track&limit=50").body[:tracks][:items]
+               next if response.blank?
+               artist_tracks = response.map do |res|
+                                 next nil if should_remove_response?(res, req[:id])
+                                 track = {
+                                  spotify_id: res[:id],
+                                  name: res[:name],
+                                  duration_ms: res[:duration_ms],
+                                  artist_id: res[:artists].pluck(:id)
+                                }
+                               end
+                artist_tracks.compact.uniq { |track| track[:name] }
+             end
+    tracks.reject!(&:blank?)
     return tracks
   end
 
-  def response_convert_tracks(response)
-    tracks = []
-    response.each do |res|
-      next if res.blank?
-      artist_tracks = []
-      res.each do |r|
-        # アーティストの同じ名前の曲を弾く
-        next if artist_tracks.pluck(:name).include?(r.name)
-        artist_tracks << {track_id: r.id, name: r.name, duration_ms: r.duration_ms}
-      end
-      tracks << artist_tracks
-    end
-    return tracks
-  end
-
-  def refine_tracks(ramdom_tracks, target_tracks)
-    if saved_playlist.max_total_duration_ms.present?
-      return saved_playlist.refine_by_duration_ms(ramdom_tracks, target_tracks)
+  # アルバムのタイプがコンピレーション、または違うアーティストの曲は弾く
+  def should_remove_response?(response, request_artist_id)
+    case 
+    when response[:album][:album_type] == 'compilation'
+      return true
+    when response[:artists].map { |artist| artist[:id] != request_artist_id }.all?
+      return true
     else
-      return saved_playlist.refine_by_max_number_of_track(ramdom_tracks, target_tracks)
+      return false
     end
   end
 end

--- a/app/services/spotify_service.rb
+++ b/app/services/spotify_service.rb
@@ -1,4 +1,7 @@
 class SpotifyService
+  INITIAL_VALUE = 0
+  INCREASE = 1
+  PLUS_FIFTY = 50
 
   protected
 
@@ -12,6 +15,7 @@ class SpotifyService
       builder.headers['Authorization'] = "Bearer #{user.access_token}"
       builder.headers['Content-Type'] = 'application/json'
       builder.headers['Accept-Language'] = 'ja;q=1'
+      builder.request :url_encoded
     end
   end
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -25,7 +25,8 @@ ja:
     delete_confirm: '%{item}を削除しますか？'
     add_track_to_playlist: 'プレイリストに曲を追加しました'
     delete_track_from_playlist: 'プレイリストから曲を削除しました'
-    not_get: "指定された%{item}を取得できませんでした"
+    not_get: "%{item}を取得できませんでした"
+    not_get_track: "%{item}の曲を取得できませんでした"
     few_track_fit_criteria: '条件に合う曲が少数でした'
     duration_time_more_than_10_minutes_shorter: '再生時間が条件より10分以上短くなりました'
     not_get_for_search_word: '検索ワードにヒットしませんでした'


### PR DESCRIPTION
## やったこと
プレイリストを作成時、日本語で検索をかけると取得できなかったので、一度英語でアーティストの名前を取得、検索し曲を取得する。
指定したアーティストが取得できない場合はアーティスト名をフラッシュメッセージに表示するように変更。
## やらないこと

## できるようになること（ユーザ目線）

どの指定したアーティストの曲を取得ができなかったのかがわかる
## できなくなること（ユーザ目線）

## 動作確認
ローカルで確認
## その他
