### PR TITLE
hotfix: ゲストユーザーのフォローアーティストが登録されていないエラー、ログインから一時間経過後の強制ログアウトされないのエラー修正

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -16,15 +16,9 @@ class Api::V1::SessionsController < ApplicationController
   end
 
   def guest_login
-    response = SpotifyGuestLogin.call
-    if response.status == 200
-      user = User.find('guest_user')
-      user.update!(access_token: response.body[:access_token])
-      session[:user_id] = user[:spotify_id]
-      redirect_to api_v1_saved_playlists_path, success: t(".success")
-    else
-      redirect_to root_path
-    end
+    guest_user = SpotifyGuestLogin.call
+    session[:user_id] = guest_user[:spotify_id]
+    redirect_to api_v1_saved_playlists_path, success: t(".success")
   end
 
   def failure

--- a/app/controllers/concerns/errors_handler.rb
+++ b/app/controllers/concerns/errors_handler.rb
@@ -7,6 +7,7 @@ module ErrorsHandler
   class NotGetTracksByTargetArtists; end
   class NotEnoughTrackInPlaylist; end
   class NotEnoughPlaybackTimeForPlaylist; end
+  class AccessTokenExpiration < StandardError; end
 
   included do
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
@@ -14,6 +15,7 @@ module ErrorsHandler
     rescue_from ErrorsHandler::NotUpdateSavedPlaylistError, with: :not_update_saved_playlist
     rescue_from ErrorsHandler::NotEnoughTrackInPlaylist, with: :not_enough_track_in_playlist
     rescue_from ErrorsHandler::NotEnoughPlaybackTimeForPlaylist, with: :not_enough_playback_time_for_playlist
+    rescue_from ErrorsHandler::AccessTokenExpiration, with: :access_token_expiration
   end
 
   private
@@ -39,5 +41,9 @@ module ErrorsHandler
 
   def render_404(exception = nil, messages = nil)
     render_error(400, 'Bad Request', exception&.message, *messages)
+  end
+
+  def access_token_expiration
+    redirect_to root_path, danger: '1時間経過したのでログアウトしました'
   end
 end

--- a/app/services/spotify_guest_login.rb
+++ b/app/services/spotify_guest_login.rb
@@ -4,7 +4,10 @@ class SpotifyGuestLogin < SpotifyService
   end
 
   def guest_login
-    request_guest_login
+    response = request_guest_login
+    user = User.find('guest_user')
+    user.update!(access_token: response.body[:access_token])
+    user
   end
 
   private

--- a/app/services/spotify_service.rb
+++ b/app/services/spotify_service.rb
@@ -44,7 +44,7 @@ class SpotifyService
     if user.guest_user?
       return if (Time.current - user.updated_at) < ONE_HOUR_IN_MS
 
-      redirect_to root_path, danger: '1時間経過したのでログアウトしました'
+      raise ErrorsHandler::AccessTokenExpiration
     else
       return if (Time.current - user.updated_at) < FIFTY_MIN_IN_MS
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,9 +10,9 @@ follow_artist_ids = []
 artist_genres = []
 
 CSV.foreach('db/guest_user/follow_artists.csv') do |row|
-  artist = Artist.find_or_create_by!(spotify_id: row[0]) do |artist|
-    artist.name = row[1],
-    artist.image = row[2]
+  artist = Artist.find_or_create_by!(spotify_id: row[0]) do |a|
+    a.name = row[1]
+    a.image = row[2]
   end
   follow_artist_ids << artist.spotify_id
 


### PR DESCRIPTION
## やったこと
ゲストユーザーのフォローアーティストが登録されていないエラーを修正、ログインから１時間後の強制ログアウトされないエラーを修正
## やらないこと
なし
## できるようになること（ユーザ目線）
ゲストログイン時に最初からフォローアーティストが登録されている状態になる
