### PR TITLE
fix: プレイリスト名が折り返されないレイアウト崩れをを修正

### DIFF
--- a/app/assets/stylesheets/playlist.scss
+++ b/app/assets/stylesheets/playlist.scss
@@ -51,9 +51,13 @@
         display: flex;
         align-items: center;
         height: 80%;
+        width: 100%;
+        flex-wrap: wrap;
 
         .playlist-title {
           font-size: clamp(1.5rem, 3vw, 3rem);
+          word-break: break-all;
+          overflow-y: scroll;
         }
       }
 


### PR DESCRIPTION
## チケットへのリンク

* https://example.com

## やったこと
プレイリスト名が長い場合に折り返されずレイアウト崩れを起こすことを修正

## やらないこと


## できるようになること（ユーザ目線）

プレイリスト名が長い場合に折返しされる