### PR TITLE
fix: プレイリストの曲を削除後残りの曲の削除ボタンが表示されないのを修正、プレイリストを追加できないバグを修正

### DIFF
--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -33,11 +33,11 @@ class Track < ApplicationRecord
       end
     end
 
-    def find_or_initialize_by_response!(response)
-      Track.find_or_initialize_by(spotify_id: response[:id]) do |track|
+    def find_or_create_by_response!(response)
+      Track.find_or_create_by(spotify_id: response[:id]) do |track|
         track.name = response[:name]
         track.duration_ms = response[:duration_ms]
-        track.position = response[:traci_number]
+        track.position = response[:track_number]
         track.album_id = response[:album][:id]
       end
     end

--- a/app/services/playlists/playlist_track_adder.rb
+++ b/app/services/playlists/playlist_track_adder.rb
@@ -19,6 +19,7 @@ class Playlists::PlaylistTrackAdder < SpotifyService
     Artists::ArtistRegistrar.call(user, pick_out_artist_ids(track), track[:album])
     playlist_of_track[:position] = PlaylistOfTrack.where(playlist_id: playlist_of_track.playlist_id).count
     playlist_of_track.save!
+    playlist_of_track
   end
 
   def request_playlist_add_track

--- a/app/views/api/v1/playlist_of_tracks/_playlist_of_track.html.slim
+++ b/app/views/api/v1/playlist_of_tracks/_playlist_of_track.html.slim
@@ -14,6 +14,6 @@ div class="playlist-of-track position-#{playlist_of_track.position}"
     - if action_name == 'show'
       .track-item.playback-time
         = playlist_of_track.track.decorate.convert_ms_to_min_and_sec
-  - if action_name == 'edit'
+  - unless action_name == 'show'
     .delete-bottom
       = link_to t("default.delete"), api_v1_playlist_playlist_of_track_path(id: playlist_of_track, playlist_id: playlist_of_track.playlist_id), method: :delete, remote: true, data: { confirm: t("message.delete_confirm", item: playlist_of_track.track.name) }, class: 'btn btn-danger btn-lg'

--- a/app/views/api/v1/searchs/_track.html.slim
+++ b/app/views/api/v1/searchs/_track.html.slim
@@ -11,7 +11,7 @@ div class="track"
         = track.album_name
     - if current_playlist
       .track-item.track-add-button
-        = link_to '追加する',
+        = link_to t("default.add"),
           api_v1_playlist_playlist_of_tracks_path(playlist_id: current_playlist, track_id: track.spotify_id),
           method: :post, 
           remote: true, 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -6,6 +6,7 @@ ja:
     logout: 'ログアウト'
     register: '登録'
     create: '作成'
+    add: '追加'
     search_word: '検索ワード'
     show: '詳細'
     edit: '編集'


### PR DESCRIPTION
## チケットへのリンク

* close #82 

## やったこと

* プレイリスト編集で曲を削除後に残りの曲の削除ボタンが表示されないバグを修正
* 曲を追加できないエラーを修正
* 追加ボタンを「追加する」から「追加」に変更

## やらないこと

## できるようになること（ユーザ目線）

* 連続で曲を削除することができる


## その他

