### PR TITLE
fix: プレイリスト作成時の時間を削減

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,9 +5,10 @@ class ApplicationController < ActionController::Base
   before_action :require_login
 
   add_flash_types :success, :secondary, :info, :warning, :danger
-
-  rescue_from Exception, with: :render_500
-  rescue_from ActiveRecord::RecordNotFound, ActionController::RoutingError, with: :render_404
+  unless Rails.env.development?
+    rescue_from Exception, with: :render_500
+    rescue_from ActiveRecord::RecordNotFound, ActionController::RoutingError, with: :render_404
+  end
 
   def js_format_flash_message(type, message)
     respond_to do |format|

--- a/app/services/saved_playlists/based_on_saved_playlist_tracks_getter.rb
+++ b/app/services/saved_playlists/based_on_saved_playlist_tracks_getter.rb
@@ -1,4 +1,7 @@
 class SavedPlaylists::BasedOnSavedPlaylistTracksGetter < SpotifyService
+  PERCENTAGE = 0.2
+  DEFAULT = 50
+  CHALLENGE = 3
   # saved_playlistの情報からクエリを作成、曲を取得、絞り込み
   def self.call(saved_playlist, user)
     new(saved_playlist: saved_playlist, user: user).get
@@ -6,19 +9,33 @@ class SavedPlaylists::BasedOnSavedPlaylistTracksGetter < SpotifyService
 
   def get
     year = saved_playlist.convert_year
-    if saved_playlist.only_follow_artist
-      artist_ids = saved_playlist.call_artist_ids
-      ramdom_tracks = search_tracks(artist_ids, year).flatten
-    end
+    total_limit = if saved_playlist.max_number_of_track
+                    saved_playlist.max_number_of_track
+                  elsif saved_playlist.max_total_duration_ms
+                    saved_playlist.max_total_duration_ms
+                  else 
+                    DEFAULT
+                  end
+
+    candidate_tracks = {ramdom_tracks: [], target_tracks: []}
 
     if saved_playlist.include_artists.present?
       target_ids = saved_playlist.include_artists.ids
       target_tracks = search_tracks(target_ids, year)
+      candidate_tracks[:target_tracks] += tracks_narrow_by_artist(target_tracks, total_limit)
+      total_limit -= limit_decrease(candidate_tracks[:target_tracks].flatten)
     end
 
-    return false if ramdom_tracks.blank? && target_tracks.blank?
-
-    saved_playlist.refine_tracks(ramdom_tracks, target_tracks)
+    CHALLENGE.times do |t|
+      if saved_playlist.only_follow_artist
+        artist_ids = saved_playlist.call_artist_ids
+        ramdom_tracks = search_tracks(artist_ids, year)
+        candidate_tracks[:ramdom_tracks] += tracks_narrow_by_artist(ramdom_tracks, total_limit).flatten
+      end
+      total_limit -= limit_decrease(candidate_tracks[:ramdom_tracks])
+      break if saved_playlist.meet_the_requirements?(candidate_tracks[:target_tracks] + candidate_tracks[:ramdom_tracks]) || total_limit <= 0
+    end
+    candidate_tracks[:ramdom_tracks].empty? && candidate_tracks[:target_tracks].empty? ? false : candidate_tracks
   end
 
   private
@@ -33,13 +50,7 @@ class SavedPlaylists::BasedOnSavedPlaylistTracksGetter < SpotifyService
   def create_request_params(ids, year)
     offset = INITIAL_VALUE
     response = []
-    loop do
-      response.concat(conn_request(language: 'en').get("artists?ids=#{ids[offset, 50].join(',')}").body[:artists])
-      break if ids.size == response.size
-
-      offset += PLUS_FIFTY
-    end
-
+    response.concat(conn_request(language: 'en').get("artists?ids=#{ids.join(',')}").body[:artists])
     response.map do |res|
       string = "artist:#{res[:name]}"
       string += year if year
@@ -48,35 +59,47 @@ class SavedPlaylists::BasedOnSavedPlaylistTracksGetter < SpotifyService
   end
 
   def request_search_tracks(request_params)
-    tracks = request_params.map do |req|
-      response = conn_request.get("search?q=#{req[:params]}&type=track&limit=50").body[:tracks][:items]
+    artists_tracks = request_params.map do |req|
+      response = conn_request.get("search?q=#{req[:params]}&type=track").body[:tracks][:items]
       next if response.blank?
-
-      artist_tracks = response.map do |res|
-        next nil if should_remove_response?(res, req[:id])
-
-        Track.new(
-          spotify_id: res[:id],
-          name: res[:name],
-          duration_ms: res[:duration_ms],
-          position: res[:traci_number],
-          artist_ids: res[:artists].pluck(:id)
-        )
-      end
-      artist_tracks.compact.uniq { |track| track[:name] }
+      response.delete_if { |res| should_remove_response?(res, req[:id]) }
     end
-    tracks.reject!(&:blank?)
-    tracks
+    artists_tracks.compact.map { |artist_track| artist_track.uniq { |track| track[:name] } }
+  end
+
+  def tracks_narrow_by_artist(artists_tracks, limit)
+    refined_tracks = []
+    artist_limit = limit * PERCENTAGE
+    artists_tracks.shuffle.each do |artist_tracks|
+      decrease = 0
+      tracks = []
+      saved_playlist.refine_tracks(artist_tracks, artist_limit).each do |track|
+        refined_track = Track.new(
+          spotify_id: track[:id],
+          name: track[:name],
+          duration_ms: track[:duration_ms],
+          position: track[:track_number],
+          artist_ids: track[:artists].pluck(:id)
+        )
+
+        tracks << refined_track
+        decrease += saved_playlist.max_total_duration_ms ? refined_track[:duration_ms] : 1
+        break if artist_limit <= decrease
+      end
+      refined_tracks << tracks
+      limit -= decrease
+      break if limit <= 0
+    end
+    refined_tracks
   end
 
   # アルバムのタイプがコンピレーション、または違うアーティストの曲は弾く
   def should_remove_response?(response, request_artist_id)
-    if response[:album][:album_type] == 'compilation'
-      true
-    elsif response[:artists].map { |artist| artist[:id] != request_artist_id }.all?
-      true
-    else
-      false
-    end
+    response[:album][:album_type] == 'compilation' || 
+    response[:artists].map { |artist| artist[:id] != request_artist_id }.all?
+  end
+
+  def limit_decrease(tracks)
+    saved_playlist.max_total_duration_ms ? tracks.pluck(:duration_ms).sum : tracks.size
   end
 end


### PR DESCRIPTION
## やったこと
プレイリスト作成の時間の削減
* 一個のクエリで取得する曲を50曲から20曲に変更
* 指定したアーティストの曲とランダムで取得したアーティストの曲を絞り込みする際に同じメソッドでわかりやすく変更

## その他
close #83 
